### PR TITLE
Lower Go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/arianvp/slog-journal
 
-go 1.22.1
+go 1.21.0
 
-require golang.org/x/sys v0.22.0
+require golang.org/x/sys v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
+golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/journal_test.go
+++ b/journal_test.go
@@ -302,7 +302,7 @@ func TestCanWriteMessageToSocket(t *testing.T) {
 		_ = handler.w.(*journalWriter).conn.SetWriteBuffer(1024)
 
 		largeLog := "Hello, World!"
-		for range 1024 {
+		for i := 0; i <= 1024; i++ {
 			largeLog += "a"
 		}
 


### PR DESCRIPTION
Hello, thanks for this project looks great.

We would love to start using this, however, our projects are still on 1.21 would you mind lowering down the requirement in `go.mod`? We are on a Go platform which is typically one to two major versions behind but supported by Red Hat.

Cheers!