### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/systemd/slog-journal/security/code-scanning/1](https://github.com/systemd/slog-journal/security/code-scanning/1)

The best way to address this problem is to add a `permissions` block specifying the minimal privileges required. Since this workflow only builds and tests Go code and does not push, create issues, or otherwise interact with write operations on the repo, it only requires read access to the repository contents. Therefore, add the following block near the top of the workflow file (either at the root, just below `name: Go`, or at the job level):
```yaml
permissions:
  contents: read
```
Adding this at the workflow root ensures that all jobs within the workflow inherit these least-privilege settings. No other imports or changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
